### PR TITLE
Speed refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,8 +226,8 @@ By default, `eye` shows the properties of an object.
 That can be customized for different objects.
 For example, `Dict`s are shown with the key then the value, and abstract types are shown with subtypes.
 To customize what's shown for `SomeType`, define `Eyeball.getobjects(x::SomeType)`.
-This method should return an array of `Pair`s describing the objects to be shown.
-The first component of the `Pair` is the key or index of the object, and the second component is the object.
+This method should return two arrays, the keys and values describing the objects to be shown.
+The first array has the keys or indexes of the object, and the second component is the child objects.
 
 The display of objects can also be customized with the following boolean methods:
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ The user can interactively browse the object tree using the following keys:
 * `enter` -- Return the object.
 * `q` -- Quit.
 
+Notes:
+
+* Arrays longer than 50 elements only have the first 50 elements shown when unfolded.
+* Some types are left folded by default (numbers, typed arrays, ...).
+* Some types are not recursed into. This includes modules. You can use `o` to open these in a new tree view.
+
 ## Examples
 
 Explore an object:
@@ -39,7 +45,8 @@ eye(a)
 ```
 ```jl
 julia> eye(a)
-[f] fields [d] docs [m/M] methodswith [o] open [r] tree [s] show [t] typeof  >   NamedTuple{(:h, :e, :f, :c, :set, :b, :x, :d, :ds, :dm), Tuple{Vector{Float64}, Expr, typeof(sin), Complex{Int64}, Set{A
+[f] fields [d] docs [m/M] methodswith [o] open [r] tree [s] show [t] typeof
+>   NamedTuple{(:h, :e, :f, :c, :set, :b, :x, :d, :ds, :dm), Tuple{Vector{Float64}, Expr, typeof(sin), Complex{Int64}, Set{A
    +  h: Vector{Float64} (5,) [0.893213, 0.120307, 0.322837, 0.0256164, 0.416702]
       e: Expr  :(5 * sin(pi * t))
        head: Symbol  :call

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The user can interactively browse the object tree using the following keys:
 
 Notes:
 
-* Arrays longer than 50 elements only have the first 50 elements shown when unfolded.
+* Arrays longer than 100 elements only have the first 100 elements shown when unfolded.
 * Some types are left folded by default (numbers, typed arrays, ...).
 * Some types are not recursed into. This includes modules. You can use `o` to open these in a new tree view.
 

--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ Eyeball exports one main tool to browse Julia objects and types.
 ```julia
 eye(object)
 eye(object, depth)
-eye(object = Main, depth = 10; interactive = true, showsize = false)
+eye(object = Main, depth = 10; interactive = true)
 ```
 
-`depth` controls the depth of folding. `showsize` controls whether the size of objects is shown.
+`depth` controls the depth of folding.
 
 The user can interactively browse the object tree using the following keys:
 
@@ -25,7 +25,6 @@ The user can interactively browse the object tree using the following keys:
 * `r` -- Return tree. Return the tree (a `FoldingTrees.Node`).
 * `s` -- Show object.
 * `t` -- Typeof. Show the type of the object in a new tree view.
-* `z` -- Size. Toggle showing size of objects.
 * `0`-`9` -- Fold to depth.
 * `enter` -- Return the object.
 * `q` -- Quit.
@@ -40,8 +39,7 @@ eye(a)
 ```
 ```jl
 julia> eye(a)
-[f] fields [d] docs [m/M] methodswith [o] open [r] tree [s] show [t] typeof [z] size [q] quit
- >   NamedTuple{(:h, :e, :f, :c, :set, :b, :x, :d, :ds, :dm), Tuple{Vector{Float64}, Expr, typeof(sin), Complex{Int64}, Set{A
+[f] fields [d] docs [m/M] methodswith [o] open [r] tree [s] show [t] typeof  >   NamedTuple{(:h, :e, :f, :c, :set, :b, :x, :d, :ds, :dm), Tuple{Vector{Float64}, Expr, typeof(sin), Complex{Int64}, Set{A
    +  h: Vector{Float64} (5,) [0.893213, 0.120307, 0.322837, 0.0256164, 0.416702]
       e: Expr  :(5 * sin(pi * t))
        head: Symbol  :call
@@ -90,7 +88,7 @@ eye()      # equivalent to `eye(Main)`
   
 ```jl
 julia> eye()
-[f] fields [d] docs [m/M] methodswith [o] open [r] tree [s] show [t] typeof [z] size [q] quit
+[f] fields [d] docs [m/M] methodswith [o] open [r] tree [s] show [t] typeof [q] quit
  >   Module
       Base: Module  Base
       Core: Module  Core
@@ -141,7 +139,7 @@ eye(Number)
   
 ```jl
 julia> eye(Number)
-[f] fields [d] docs [m/M] methodswith [o] open [r] tree [s] show [t] typeof [z] size [q] quit
+[f] fields [d] docs [m/M] methodswith [o] open [r] tree [s] show [t] typeof [q] quit
  >   DataType
    +  : UnionAll  Complex
       : DataType  Real
@@ -227,13 +225,12 @@ The first component of the `Pair` is the key or index of the object, and the sec
 The display of objects can also be customized with the following boolean methods:
 
 ```julia
-Eyeball.shouldrecurse(x, len)   
+Eyeball.shouldrecurse(x)   
 Eyeball.foldobject(x)   
 ```
 
-`shouldrecurse` controls whether `eye` recurses into the object.
-`x` is the object. `len` is the length of the object. 
-This defaults to `true` when `len < 30`.
+`shouldrecurse` controls whether `eye` recurses into object `x`.
+This defaults to `true`.
 For overly large or complex objects, it helps to return `false`.
 That's done internally for `Module`s, `Method`s, and a few other types.
 `foldobject` controls whether `eye` automatically folds the object.

--- a/src/Eyeball.jl
+++ b/src/Eyeball.jl
@@ -320,7 +320,7 @@ function getoptions(x::DataType)
     return (fields, fieldtypes)
 end
 function getoptions(x::AbstractArray{T}) where T
-    keys = 1:min(50, length(x))
+    keys = 1:min(100, length(x))
     return (keys, x)
 end
 function getoptions(x::AbstractDict{<:S, T}) where {S<:Union{AbstractString, Symbol, Number},T}

--- a/src/Eyeball.jl
+++ b/src/Eyeball.jl
@@ -280,8 +280,8 @@ extras(x::AbstractArray) = style(string(size(x)), color = :magenta) * " " * styl
 ```
 getfields(x)
 ```
-Return an array of Pairs describing the objects to be shown when fields are selected. 
-The first component of the Pair is the key or index of the object, and the second component is the object.
+Return a tuple of two arrays describing the child objects to be shown for `x`. 
+The first array has the field names of `x`, and the second array has the fields.
 Normally, this should not have a custom definition for a type.
 Use `getoptions` for that.
 """
@@ -296,8 +296,8 @@ end
 ```
 getoptions(x)
 ```
-Return an array of Pairs describing the child objects to be shown for `x`. 
-The first component of the Pair is the key or index of the child object, and the second component is the child object.
+Return a tuple of two arrays describing the child objects to be shown for `x`. 
+The first array has the keys or indexes of the child objects, and the second array is the child objects.
 """
 function getoptions(x::T) where T
     keys = propertynames(x)

--- a/src/Eyeball.jl
+++ b/src/Eyeball.jl
@@ -257,8 +257,7 @@ function tostring(key, obj)
     sobj = String(take!(io.io))
     string(style(string(key), color = :cyan), ": ", 
            style(string(typeof(obj)), color = :green), " ", 
-           style(string(extras(obj)), color = :magenta), " ", 
-           style(string(sizeof(obj)), color = :yellow), " ",
+           extras(obj), " ", 
            sobj)
 end
 
@@ -271,7 +270,7 @@ Returns a string with any extra information about `x`.
 For AbstractArrays, this returns size information.
 """
 extras(x) = ""
-extras(x::AbstractArray) = string(size(x))
+extras(x::AbstractArray) = style(string(size(x)), color = :magenta) * " " * style(string(sizeof(x)), color = :yellow)
 
 """
 ```

--- a/src/vendor/FoldingTrees/src/abstracttrees.jl
+++ b/src/vendor/FoldingTrees/src/abstracttrees.jl
@@ -4,4 +4,4 @@ AbstractTrees.children(node::Node) = node.foldchildren ? typeof(node)[] : node.c
 
 AbstractTrees.printnode(io::IO, node::Node) = print(io, node.foldchildren ? "+ " : "  ", node.data)
 
-#Base.show(io::IO, x::Node) = print_tree(io, x)
+Base.show(io::IO, x::Node) = print_tree(io, x)

--- a/src/vendor/FoldingTrees/src/abstracttrees.jl
+++ b/src/vendor/FoldingTrees/src/abstracttrees.jl
@@ -4,4 +4,4 @@ AbstractTrees.children(node::Node) = node.foldchildren ? typeof(node)[] : node.c
 
 AbstractTrees.printnode(io::IO, node::Node) = print(io, node.foldchildren ? "+ " : "  ", node.data)
 
-Base.show(io::IO, x::Node) = print_tree(io, x)
+#Base.show(io::IO, x::Node) = print_tree(io, x)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -32,7 +32,7 @@ end
     foreach(unfold!, nodes(root))
     FoldingTrees.print_tree(io, root)
     s = String(take!(io))
-    @test s[1:100] == "  \e[33mNamedTuple{(:h, :e, :f, :c, :set, :b, :x, :d, :ds, :dm), Tuple{Vector{Float64}, Expr, typeof("
+    @test s[1:100] == "  : \e[32mNamedTuple{(:h, :e, :f, :c, :set, :b, :x, :d, :ds, :dm), Tuple{Vector{Float64}, Expr, typeo"
     root = eye(a, 2, interactive = false)
     @test count_open_leaves(root) == 30
     root = eye(a, interactive = false)
@@ -51,7 +51,7 @@ end
     str = String(take!(io))
     nback, lines = linesplitter(str)
     @test nback == 0
-    @test lines[2] == " > +  \e[36mh\e[39m: \e[32mVector{Float64}\e[39m \e[35m(5,)\e[39m [0.0, 0.0, 0.0, 0.0, 0.0]"
+    @test lines[2] == " > +  \e[36mh\e[39m: \e[32mVector{Float64}\e[39m \e[35m(5,)\e[39m \e[33m40\e[39m [0.0, 0.0, 0.0, 0.0, 0.0]"
     @test lines[8] == "   +  \e[36mx\e[39m: \e[32mPair{Int64, UnitRange{Int64}}\e[39m  9=>99:109"
     @test length(lines) == 11
     menu.cursoridx = 11


### PR DESCRIPTION
* More concrete types
* Delay printing to strings
* Simplify `getoptions`
* Remove repeat `getoption` calls