### PR TITLE
Fix getoptions for cases where isdefined isn't defined

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Eyeball"
 uuid = "ce36242b-ad83-4f84-8519-47cd8aeefd60"
 authors = ["Tom Short <tshort.rlists@gmail.com>"]
-version = "0.3.0"
+version = "0.3.1"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/Eyeball.jl
+++ b/src/Eyeball.jl
@@ -365,7 +365,11 @@ The first array has the keys or indexes of the child objects, and the second arr
 """
 function getoptions(x)
     keys = propertynames(x)
-    values = (isdefined(x, pn) ? getproperty(x, pn) : UNDEF for pn in keys)
+    if keys === fieldnames(typeof(x))
+        values = (isdefined(x, pn) ? getproperty(x, pn) : UNDEF for pn in keys)
+    else
+        values = (getproperty(x, pn) for pn in keys)
+    end
     return zip(keys, values)
 end
 function getoptions(x::All)


### PR DESCRIPTION
Fixes DataFrames and other types with `getproperty`, but `isdefined` doesn't work.

There needs to be a check to see if `getproperty` defaults to `getfield`.