### PR TITLE
add support for MAT files

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,7 @@ AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
 FoldingTrees = "1eca21be-9b9b-4ed8-839a-6d8ae26b1781"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 TerminalPager = "0c614874-6106-40ed-a7c2-2f1cd0bff883"
 

--- a/src/Eyeball.jl
+++ b/src/Eyeball.jl
@@ -14,6 +14,8 @@ using AbstractTrees
 import TerminalPager
 using Statistics
 
+using Requires
+
 
 # TODO: de-vendor once changes are upstreamed.
 # include("vendor/FoldingTrees/src/FoldingTrees.jl")
@@ -465,6 +467,10 @@ function getoptions(x::AbstractDict)
 end
 function getoptions(x::AbstractSet{T}) where T
     return zip(Iterators.repeated(Symbol("")), x)
+end
+
+function __init__()
+    @require MAT="23992714-dd62-5051-b70f-ba57cb901cac" getoptions(x::MAT.MAT_HDF5.MatlabHDF5File) = zip(keys(x), (read(x,k) for k in keys(x)))
 end
 
 iscorejunk(x) = parentmodule(parentmodule(parentmodule(x))) === Core && !isabstracttype(x) && isstructtype(x)


### PR DESCRIPTION
related to https://github.com/tshort/Eyeball.jl/issues/25 since MAT files are HDF5

adds a dependency on Requires to avoid depending on MAT.  i think this should be okay since in future no other deps will need to be added to support, e.g., HDF5 or any other package that defines a tree.

also, the [docstring](https://github.com/tshort/Eyeball.jl/blob/master/src/Eyeball.jl#L418-L424) for `getoptions` says "Return a tuple of two arrays" when it appears to really return a vector of 2-tuples.