### PR TITLE
Add display of sizes

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,7 +16,6 @@ jobs:
           - '1.6'
           - '1.7'
           - '1.8'
-          - 'nightly'
         os:
           - ubuntu-latest
           - macOS-latest

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Eyeball"
 uuid = "ce36242b-ad83-4f84-8519-47cd8aeefd60"
 authors = ["Tom Short <tshort.rlists@gmail.com>"]
-version = "0.4.7"
+version = "0.5.0"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.5.0"
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
 FoldingTrees = "1eca21be-9b9b-4ed8-839a-6d8ae26b1781"
+Humanize = "7ec9b9c5-1998-51e1-b7fc-fc3590c18259"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ The user can interactively browse the object tree using the following keys:
 * `t` -- Typeof. Show the type of the object in a new tree view.
 * `z` -- Summarize. Toggle a summary of the object and child objects. 
   For arrays, this shows the mean and 0, 25, 50, 75, and 100% quantiles (skipping missings).
+* `.` -- Sizes. Toggle display of sizes between none, `Base.summarysize` (includes subobjects), and `sizeof`.
 * `0`-`9` -- Fold to depth. Also toggles expansion of items normally left folded.
 * `enter` -- Return the selected object.
 * `q` -- Quit.

--- a/src/Eyeball.jl
+++ b/src/Eyeball.jl
@@ -23,7 +23,7 @@ using FoldingTrees
 
 export eye
 
-SIZE = :none
+SIZE = Ref(:none)
 
 default_terminal() = REPL.LineEdit.terminal(Base.active_repl)
 """
@@ -198,13 +198,14 @@ function eye(x = Main, depth = 10; interactive = true, all = false)
                 end
             end
         elseif i == Int('.')
-            if SIZE == :none
-                SIZE = :displaysize
-            elseif SIZE == :displaysize
-                SIZE = :sizeof
+            if SIZE[] == :none
+                SIZE[] = :displaysize
+            elseif SIZE[] == :displaysize
+                SIZE[] = :sizeof
             else
-                SIZE = :none
+                SIZE[] = :none
             end
+            redo = true
             return true
         elseif i in Int.('0':'9')
             node = FoldingTrees.setcurrent!(menu, menu.cursoridx)
@@ -382,8 +383,8 @@ function tostring(key, value)
     io = IOContext(IOBuffer(), :compact => true, :limit => true, :color => true, :displaysize => (3,200))
     show(io, value)
     svalue = String(take!(io.io))
-    sz = SIZE == :none ? "" :
-         SIZE == :sizeof ? string(sizeof(value)) : string(summarysize(value))
+    sz = SIZE[] == :none ? "" :
+         SIZE[] == :sizeof ? string(sizeof(value)) : string(Base.summarysize(value))
     string(style(string(key), color = :cyan), ": ", 
            style(string(typeof(value)), color = :green), " ", 
            style(sz, color = :blue), " ", 

--- a/src/Eyeball.jl
+++ b/src/Eyeball.jl
@@ -221,7 +221,7 @@ function eye(x = Main, depth = 10; interactive = true, all = false)
         term = default_terminal()
         while true
             menu = TreeMenu(root, pagesize = REPL.displaysize(term)[1] - 2, dynamic = true, keypress = keypress)
-            choice = TerminalMenus.request(term, "[f] fields [d] docs [e] expand [m/M] methodswith [o] open [r] tree [s] show [S] Sort [t] typeof [z] summarize [q] quit", menu; cursor=cursor)
+            choice = TerminalMenus.request(term, "[f] fields [d] docs [e] expand [m/M] methodswith [o] open [r] tree [s] show [S] Sort [t] typeof [z] summarize [.] size [q] quit", menu; cursor=cursor)
             choice !== nothing && return returnfun(choice)
             if redo
                 redo = false

--- a/src/Eyeball.jl
+++ b/src/Eyeball.jl
@@ -14,6 +14,8 @@ using AbstractTrees
 import TerminalPager
 using Statistics
 
+using Humanize
+
 
 # TODO: de-vendor once changes are upstreamed.
 # include("vendor/FoldingTrees/src/FoldingTrees.jl")
@@ -384,13 +386,15 @@ function tostring(key, value)
     show(io, value)
     svalue = String(take!(io.io))
     sz = SIZE[] == :none ? "" :
-         SIZE[] == :sizeof ? string(sizeof(value)) : string(Base.summarysize(value))
+         SIZE[] == :sizeof ? hustring(sizeof(value)) : hustring(Base.summarysize(value))
     string(style(string(key), color = :cyan), ": ", 
            style(string(typeof(value)), color = :green), " ", 
            style(sz, color = :blue), " ", 
            extras(value), " ", 
            svalue)
 end
+
+hustring(bytes) = Humanize.datasize(bytes, style=:bin, format = "%.0f")
 
 function tostring(key, value::UNDEFPlaceholder)
     string(style(string(key), color = :cyan), ": #undef")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -51,8 +51,8 @@ end
     str = String(take!(io))
     nback, lines = linesplitter(str)
     @test nback == 0
-    @test lines[2] == " > +  \e[36mh\e[39m: \e[32mVector{Float64}\e[39m \e[35m(5,)\e[39m \e[33m40\e[39m [0.0, 0.0, 0.0, 0.0, 0.0]"
-    @test lines[8] == "   +  \e[36mx\e[39m: \e[32mPair{Int64, UnitRange{Int64}}\e[39m  9=>99:109"
+    @test lines[2] == " > +  \e[36mh\e[39m: \e[32mVector{Float64}\e[39m  \e[35m(5,)\e[39m [0.0, 0.0, 0.0, 0.0, 0.0]"
+    @test lines[8] == "   +  \e[36mx\e[39m: \e[32mPair{Int64, UnitRange{Int64}}\e[39m   9=>99:109"
     @test length(lines) == 11
     menu.cursoridx = 11
     # TerminalMenus.keypress(menu, UInt32('f'))


### PR DESCRIPTION
Now `.` toggles between:

* None
* Display using `Base.summarysize`. This total includes the size of subcomponents.
* `sizeof`
